### PR TITLE
fix dispatcher

### DIFF
--- a/app/src/main/java/com/smaillimp/yatzy/di/AppModule.kt
+++ b/app/src/main/java/com/smaillimp/yatzy/di/AppModule.kt
@@ -49,6 +49,6 @@ object AppModule {
     @Provides
     @Singleton
     fun providesDefaultDispatcher(): CoroutineDispatcher {
-        return Dispatchers.Default
+        return Dispatchers.Main
     }
 }


### PR DESCRIPTION
using Dispatcher.Default caused an issue when injected. Therefore, switching to Dispatcher.Main.

Error message if using Dispatcher.Default:
```
2022-12-01 19:01:22.959 8557-8582/com.smaillimp.yatzy E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-1
    Process: com.smaillimp.yatzy, PID: 8557
    java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied
```

For difference between dispatchers see:
https://stackoverflow.com/questions/59646948/what-is-the-difference-between-dispatchers-main-and-dispatchers-default-in-kotli